### PR TITLE
Update Vault from vault:1.12.2 -> hashicorp/vault:1.15

### DIFF
--- a/spec/commands_spec.rb
+++ b/spec/commands_spec.rb
@@ -18,7 +18,7 @@ describe 'commands' do
 
   it 'includes the vault command' do
     expect(command('/bin/vault --version').stdout)
-      .to match(/1.12/)
+      .to match(/1.15/)
   end
 
   it 'includes the envsubst command' do

--- a/src/vault-aws/Dockerfile
+++ b/src/vault-aws/Dockerfile
@@ -1,4 +1,4 @@
-FROM vault:1.12.2 as vault
+FROM hashicorp/vault:1.15 as vault
 
 FROM infrablocks/alpine-aws-s3-config:0.23.0
 


### PR DESCRIPTION
This is a minor version update so it should be relatively safe to deploy if users aren't using any depreciated features.

Depreciation notices can be view here:
https://developer.hashicorp.com/vault/docs/deprecation

Notes:
- Since version 1.14 the official Vault dockerhub image is now only published from Hashicorp Verified publisher images.
- It might also be worth considering an update to [infrablocks/docker-base-alpine-aws](https://github.com/infrablocks/docker-base-alpine-aws) before generating a new release candidate as there are a few infrablocks modules that were last updated in January.

Authors: @chris-emerson